### PR TITLE
Fix KYUTAI_API_KEY naming + sample rate mismatch between Gradium and Kyutai TTS

### DIFF
--- a/services/backend/backend/kyutai_constants.py
+++ b/services/backend/backend/kyutai_constants.py
@@ -18,7 +18,7 @@ KYUTAI_STT_URL = os.environ["KYUTAI_STT_URL"]
 TTS_IS_GRADIUM = is_env_true("TTS_IS_GRADIUM")
 TTS_SERVER = os.environ["TTS_SERVER"]
 
-KYUTAI_TTS_API_KEY = os.environ.get("KYUTAI_TTS_API_KEY")
+KYUTAI_API_KEY = os.environ.get("KYUTAI_API_KEY")
 
 LLM_API_KEY = os.environ["KYUTAI_LLM_API_KEY"]
 LLM_URL = os.environ["KYUTAI_LLM_URL"]

--- a/services/backend/backend/routes/tts.py
+++ b/services/backend/backend/routes/tts.py
@@ -8,7 +8,7 @@ from fastapi.security import HTTPBearer
 from starlette.responses import Response
 
 from backend.kyutai_constants import (
-    KYUTAI_TTS_API_KEY,
+    KYUTAI_API_KEY,
     TTS_IS_GRADIUM,
     TTS_SERVER,
     get_tts_setup,
@@ -60,7 +60,7 @@ async def text_to_speech(
         response = await client.post(
             TTS_SERVER,
             json=query,
-            headers={"kyutai-api-key": KYUTAI_TTS_API_KEY},
+            headers={"kyutai-api-key": KYUTAI_API_KEY},
         )
 
     response.raise_for_status()
@@ -78,3 +78,11 @@ async def text_to_speech(
             "Cache-Control": "no-cache",
         },
     )
+
+
+@tts_router.get("/sample_rate")
+async def get_tts_sample_rate() -> Response:
+    if TTS_IS_GRADIUM:
+        return {"sample_rate": 48000} # Could be obtained from gradium client ?
+    else:
+        return {"sample_rate": 24000} # Kyutai TTS sample rate

--- a/services/frontend/src/utils/ttsUtil.ts
+++ b/services/frontend/src/utils/ttsUtil.ts
@@ -14,7 +14,10 @@ export interface TTSOptions {
 export async function playTTSStream(
   options: TTSOptions,
 ): Promise<AudioContext> {
-  const SAMPLE_RATE = 48000;
+  /* Fetch sample rate from backend */
+  const SAMPLE_RATE = await fetch('/api/v1/tts/sample_rate').then((res) =>
+    res.json().then((data) => data.sample_rate),
+  );
   const { text, messageId, cacheType = 'temporary' } = options;
   const audioContext = new AudioContext({ sampleRate: SAMPLE_RATE });
 


### PR DESCRIPTION
This should fix the issue with Kyutai TTS sample rate. 
Also the readme ask to use environment variable KYUTAI_API_KEY but it was KYUTAI_TTS_API_KEY inside the code. 